### PR TITLE
Run fewer CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,9 @@ jobs:
       matrix:
         version:
           - '1.5'
-          - 'nightly'
+          - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
     steps:


### PR DESCRIPTION
Drop non-Linux jobs. Also replace Julia nightly with the most recent Julia 1.x.