### PR TITLE
Drop arm64 Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
           context: .
           platforms: |
             linux/amd64
-            ${{ (inputs.arm64 || github.event_name == 'push') && 'linux/arm64' || '' }}
+            ${{ inputs.arm64 && 'linux/arm64' || '' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
`linux/arm64` builds are not working with GitHub Actions