### PR TITLE
Fix catastrophic cancellation in VanGenuchten Dθ near θr

### DIFF
--- a/src/PorousModels/PorousModels.jl
+++ b/src/PorousModels/PorousModels.jl
@@ -3,7 +3,7 @@ module PorousModels
 import ..Fronts: DiffusionEquation
 
 using ForwardDiff: derivative
-using NaNMath: pow
+using NaNMath: pow, log1p
 using ArgCheck: @argcheck
 
 include("base.jl")

--- a/src/PorousModels/vangenuchten.jl
+++ b/src/PorousModels/vangenuchten.jl
@@ -113,7 +113,8 @@ end
 
 function Dθ(pm::VanGenuchten, θ)
     Se = (θ - pm.θr) / (pm.θs - pm.θr)
+    # (1-x)^(-m) + (1-x)^m - 2 loses all precision near θr; expm1/log1p form is exact
+    u = pm.m * log1p(-pow(Se, 1 / pm.m))
     return (1 - pm.m) * pm.Ks / (pm.α * pm.m * (pm.θs - pm.θr)) * pow(Se, pm.l) *
-           pow(Se, -1 / pm.m) *
-           (pow(1 - pow(Se, 1 / pm.m), -pm.m) + pow(1 - pow(Se, 1 / pm.m), pm.m) - 2)
+           pow(Se, -1 / pm.m) * expm1(u)^2 * exp(-u)
 end

--- a/test/test_PorousModels.jl
+++ b/test/test_PorousModels.jl
@@ -60,5 +60,39 @@
         @test (@inferred Kh(vg, @inferred hθ(vg, θtest))) ≈ @inferred Kθ(vg, θtest)
         @test (@inferred Dθ(vg, θtest)) ≈
               (@inferred Kθ(vg, θtest)) / @inferred Cθ(vg, θtest)
+
+        @testset "Dθ near θr" begin
+            # BigFloat reference of Van Genuchten (1980) eq. 11
+            function Dref(pm, θ)
+                m = BigFloat(pm.m)
+                Se = (BigFloat(θ) - pm.θr) / (BigFloat(pm.θs) - pm.θr)
+                x = Se^(1 / m)
+                (1 - m) * pm.Ks / (pm.α * m * (BigFloat(pm.θs) - pm.θr)) * Se^pm.l *
+                Se^(-1 / m) * ((1 - x)^(-m) + (1 - x)^m - 2)
+            end
+
+            setprecision(BigFloat, 1200) do
+                for n in (1.1, 2.0, 5.0), l in (0.0, 0.5, 2.0),
+                    Se in (1e-1, 1e-3, 1e-6, 1e-9, 1e-12)
+                    vgn = VanGenuchten(n = n, l = l, α = α, k = k, θr = θr, θs = θs)
+                    θn = θr + Se * (θs - θr)
+                    @test (@inferred Dθ(vgn, θn))≈Float64(Dref(vgn, θn)) rtol=1e-12 atol=0
+                end
+
+                # solver differentiates D: first derivative must survive near θr too
+                θn = θr + 1e-6 * (θs - θr)
+                h = big"1e-30"
+                dref = Float64((Dref(vg, BigFloat(θn) + h) - Dref(vg, BigFloat(θn) - h)) /
+                               (2h))
+                @test ForwardDiff.derivative(θ -> Dθ(vg, θ), θn)≈dref rtol=1e-10 atol=0
+                @test isfinite(ForwardDiff.derivative(
+                    θ -> ForwardDiff.derivative(s -> Dθ(vg, s), θ), θn))
+            end
+
+            # out-of-range and saturation behavior is unchanged
+            @test isnan(@inferred Dθ(vg, θs + 0.01))
+            @test isnan(@inferred Dθ(vg, θr - 0.01))
+            @test isinf(@inferred Dθ(vg, θs))
+        end
     end
 end

--- a/test/test_dirichlet.jl
+++ b/test/test_dirichlet.jl
@@ -84,6 +84,19 @@
         @test isnan(@inferred θ(-1, t))
     end
 
+    @testset "HF135 dry initial condition" begin
+        # near-θr initial condition; fails to converge if Dθ underflows there
+        θr = 0.0473
+        θs = 0.945
+
+        model = VanGenuchten(n = 1.5, α = 0.2555, k = 5.50e-13, θr = θr, θs = θs)
+
+        prob = DirichletProblem(model, i = θr + 1e-3 * (θs - θr), b = θs - 1e-7)
+
+        θ = solve(prob, abstol = 1e-7)
+        @test SciMLBase.successful_retcode(θ)
+    end
+
     @testset "validity LET" begin
         # Wetting of a Whatman No. 1 paper strip
         # Reference: Gerlero et al. (2022)


### PR DESCRIPTION
`Dθ(::VanGenuchten, θ)` evaluates `(1-x)^(-m) + (1-x)^m - 2` with `x = Se^(1/m)`; both powers approach 1 as θ → θr, so the `-2` cancels essentially all significant digits. Against a 1200-bit `BigFloat` reference over n ∈ [1.1, 10], l ∈ [0, 2], Se ∈ [1e-12, 0.1], 144 of 224 points return exact `0.0` where the true diffusivity is nonzero (at n = 1.1 it is already fully zeroed at Se = 0.1), and ForwardDiff derivatives of D degrade the same way. Same bug as gerlero/fronts#152.

The fix rewrites the bracket as `expm1(u)^2 * exp(-u)` with `u = m * log1p(-x)` (algebraically identical), taking the worst relative error on that grid from 1.0 down to ~1e-13. `NaNMath.log1p` keeps NaN for θ outside [θr, θs]; θ = θs still returns Inf and wet-end values are unchanged. `BrooksAndCorey`, `LETxs` and `LETd` have no equivalent cancelling term. A `DirichletProblem` with n = 1.5 and θi = θr + 1e-3(θs − θr) went from MaxIters to converging in 25 iterations.

Tests: near-θr grid pinned against the `BigFloat` reference, first-derivative check, out-of-range/saturation pins, and the dry-end solve above.
